### PR TITLE
Fixed authentication backend

### DIFF
--- a/django_nopassword/backends.py
+++ b/django_nopassword/backends.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 from django.conf import settings
+from django.core.exceptions import FieldError
 
 from django_nopassword.utils import User
 from django_nopassword.models import LoginCode
@@ -25,7 +26,7 @@ class EmailBackend:
                 user.code = login_code
                 login_code.delete()
                 return user
-        except (TypeError, User.DoesNotExist, LoginCode.DoesNotExist):
+        except (TypeError, User.DoesNotExist, LoginCode.DoesNotExist, FieldError):
             return None
 
     def get_user(self, user_id):

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages=find_packages(exclude='tests'),
     tests_require=[
         'django>=1.4',
+        'mock==1.0.1',
     ],
     test_suite='runtests.runtests',
     include_package_data=True,

--- a/tests/models.py
+++ b/tests/models.py
@@ -15,3 +15,10 @@ class CustomUser(AbstractUser):
     def save(self, *args, **kwargs):
         self.new_username_field = self.username
         super(CustomUser, self).save(*args, **kwargs)
+
+
+class NoUsernameUser(models.Model):
+    """User model without a "username" field for authentication
+    backend testing
+    """
+    pass

--- a/tests/settings_sqlite3.py
+++ b/tests/settings_sqlite3.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+DEBUG = False
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+try:
+    from local import *
+except ImportError:
+    pass
+
+AUTH_USER_MODEL = 'tests.CustomUser'
+
+NOPASSWORD_LOGIN_CODE_TIMEOUT = 900
+
+INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+
+    'django_nopassword',
+    'tests',
+]
+AUTHENTICATION_BACKENDS = (
+    'django_nopassword.backends.EmailBackend',
+    'django.contrib.auth.backends.ModelBackend'
+)
+
+TIME_ZONE = 'America/Chicago'
+LANGUAGE_CODE = 'en-us'
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+)
+
+SECRET_KEY = 'supersecret'
+
+TEMPLATE_LOADERS = (
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+)
+
+ROOT_URLCONF = 'tests.urls'
+
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,7 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 import time
+
+import mock
 
 from django.contrib.auth import authenticate
 from django.test import Client
@@ -11,6 +13,8 @@ from django_nopassword import views
 
 from django_nopassword.models import LoginCode
 from django_nopassword.utils import User
+
+from .models import NoUsernameUser
 
 
 class TestLoginCodes(unittest.TestCase):
@@ -43,6 +47,19 @@ class TestLoginCodes(unittest.TestCase):
     def tearDown(self):
         self.user.delete()
         self.inactive_user.delete()
+
+
+class AuthenticationBackendTests(unittest.TestCase):
+
+    def test_authenticate_with_custom_user_model(self):
+        """When a custom user model is used that doesn't have a field
+        called "username" return `None`
+        """
+
+        with mock.patch('django_nopassword.backends.User', new=NoUsernameUser):
+            result = authenticate(username='username')
+
+            self.assertIsNone(result)
 
 
 class TestViews(unittest.TestCase):


### PR DESCRIPTION
A custom user model without a field called "username" can be used as
`AUTH_USER_MODEL`, the backend now returns `None` for a user model
without a "username" field allowing the next backend (if any) to
handle authentication. Previously it was raising: "FieldError: Cannot
resolve keyword 'username' into field."
