### PR TITLE
minor doc fix concerning NOPASSWORD_HIDE_USERNAME

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -16,7 +16,7 @@ django-nopassword settings
 
 .. attribute:: NOPASSWORD_HIDE_USERNAME
 
-    If set to True, the login url will not contain
+    If set to True, the login url will not contain the username.
 
 .. attribute:: NOPASSWORD_LOGIN_EMAIL_SUBJECT
 


### PR DESCRIPTION
The explanation about NOPASSWORD_HIDE_USERNAME (inserted in 6721e82) got cut off.
