### PR TITLE
add SMS support

### DIFF
--- a/nopassword/backends/__init__.py
+++ b/nopassword/backends/__init__.py
@@ -10,7 +10,7 @@ from nopassword.utils import get_user_model
 from nopassword.models import LoginCode
 
 
-class NoPasswordBackend:
+class NoPasswordBackend(object):
     def authenticate(self, code=None, **credentials):
         try:
             user = get_user_model().objects.get(**credentials)

--- a/nopassword/backends/sms.py
+++ b/nopassword/backends/sms.py
@@ -1,14 +1,14 @@
 from django.conf import settings
 from django.core import checks
+from django.template.loader import render_to_string
 from nopassword.backends import NoPasswordBackend
-
 from twilio.rest import TwilioRestClient
 
 
 class SMSBackend(NoPasswordBackend):
-    def __init__(self, *args, **kwargs):
+    def __init__(self):
         self.twilio_client = TwilioRestClient(settings.NOPASSWORD_TWILIO_SID, settings.NOPASSWORD_TWILIO_AUTH_TOKEN)
-        super(SMSBackend, self).__init__(*args, **kwargs)
+        super(SMSBackend, self).__init__()
 
     def send_login_code(self, code):
         """
@@ -19,4 +19,4 @@ class SMSBackend(NoPasswordBackend):
         context = {'url': code.login_url(), 'code': code}
         sms_content = render_to_string('registration/login_sms.txt', context)
 
-        self.client.message.create(to=code.user.phone_number, from=from_number, body=sms_content)
+        self.twilio_client.messages.create(to=code.user.phone_number, from_=from_number, body=sms_content)

--- a/nopassword/templates/registration/login_sms.html
+++ b/nopassword/templates/registration/login_sms.html
@@ -1,1 +1,0 @@
-{% load i18n %}{% trans "Login with this url " %}{{ url }}

--- a/tests/models.py
+++ b/tests/models.py
@@ -16,6 +16,8 @@ class CustomUser(AbstractUser):
         self.new_username_field = self.username
         super(CustomUser, self).save(*args, **kwargs)
 
+class PhoneNumberUser(CustomUser):
+    phone_number = models.CharField(max_length=11, default="+19714007257")
 
 class NoUsernameUser(models.Model):
     """User model without a "username" field for authentication


### PR DESCRIPTION
I added an SMS backend -- I've tested locally (it works!) but I can add tests that flex the backend if desired -- we'll want to use Mock so as not to require actual Twilio credentials or SMS costs.
