### PR TITLE
Support 'https' in login url

### DIFF
--- a/nopassword/backends/base.py
+++ b/nopassword/backends/base.py
@@ -32,7 +32,7 @@ class NoPasswordBackend(object):
         except get_user_model().DoesNotExist:
             return None
 
-    def send_login_code(self, code, secure=False):
+    def send_login_code(self, code, secure=False, **kwargs):
         raise NotImplementedError
 
     def verify_user(self, user):

--- a/nopassword/backends/base.py
+++ b/nopassword/backends/base.py
@@ -32,7 +32,7 @@ class NoPasswordBackend(object):
         except get_user_model().DoesNotExist:
             return None
 
-    def send_login_code(self, code):
+    def send_login_code(self, code, secure=False):
         raise NotImplementedError
 
     def verify_user(self, user):

--- a/nopassword/backends/email.py
+++ b/nopassword/backends/email.py
@@ -9,12 +9,12 @@ from .base import NoPasswordBackend
 
 class EmailBackend(NoPasswordBackend):
 
-    def send_login_code(self, code, secure=False):
+    def send_login_code(self, code, secure=False, **kwargs):
         subject = getattr(settings, 'NOPASSWORD_LOGIN_EMAIL_SUBJECT', _('Login code'))
         to_email = [code.user.email]
         from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'root@example.com')
 
-        context = {'url': code.login_url(secure), 'code': code}
+        context = {'url': code.login_url(secure=secure), 'code': code}
         text_content = render_to_string('registration/login_email.txt', context)
         html_content = render_to_string('registration/login_email.html', context)
 

--- a/nopassword/backends/email.py
+++ b/nopassword/backends/email.py
@@ -9,12 +9,12 @@ from .base import NoPasswordBackend
 
 class EmailBackend(NoPasswordBackend):
 
-    def send_login_code(self, code):
+    def send_login_code(self, code, secure=False):
         subject = getattr(settings, 'NOPASSWORD_LOGIN_EMAIL_SUBJECT', _('Login code'))
         to_email = [code.user.email]
         from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'root@example.com')
 
-        context = {'url': code.login_url(), 'code': code}
+        context = {'url': code.login_url(secure), 'code': code}
         text_content = render_to_string('registration/login_email.txt', context)
         html_content = render_to_string('registration/login_email.html', context)
 

--- a/nopassword/backends/sms.py
+++ b/nopassword/backends/sms.py
@@ -14,13 +14,13 @@ class TwilioBackend(NoPasswordBackend):
         )
         super(TwilioBackend, self).__init__()
 
-    def send_login_code(self, code):
+    def send_login_code(self, code, secure=False):
         """
         Send a login code via SMS
         """
         from_number = getattr(settings, 'DEFAULT_FROM_NUMBER')
 
-        context = {'url': code.login_url(), 'code': code}
+        context = {'url': code.login_url(secure), 'code': code}
         sms_content = render_to_string('registration/login_sms.txt', context)
 
         self.twilio_client.messages.create(

--- a/nopassword/backends/sms.py
+++ b/nopassword/backends/sms.py
@@ -14,13 +14,13 @@ class TwilioBackend(NoPasswordBackend):
         )
         super(TwilioBackend, self).__init__()
 
-    def send_login_code(self, code, secure=False):
+    def send_login_code(self, code, secure=False, **kwargs):
         """
         Send a login code via SMS
         """
         from_number = getattr(settings, 'DEFAULT_FROM_NUMBER')
 
-        context = {'url': code.login_url(secure), 'code': code}
+        context = {'url': code.login_url(secure=secure), 'code': code}
         sms_content = render_to_string('registration/login_sms.txt', context)
 
         self.twilio_client.messages.create(

--- a/nopassword/models.py
+++ b/nopassword/models.py
@@ -33,7 +33,7 @@ class LoginCode(models.Model):
             self.next = '/'
         super(LoginCode, self).save(*args, **kwargs)
 
-    def login_url(self):
+    def login_url(self, secure=False):
         username = get_username(self.user)
         if getattr(settings, 'NOPASSWORD_HIDE_USERNAME', False):
             view = reverse_lazy('nopassword.views.login_with_code', args=[self.code]),
@@ -41,16 +41,17 @@ class LoginCode(models.Model):
             view = reverse_lazy('nopassword.views.login_with_code_and_username',
                                 args=[username, self.code]),
 
-        return 'http://%s%s?next=%s' % (
+        return '%s://%s%s?next=%s' % (
+            'https' if secure else 'http',
             getattr(settings, 'SERVER_URL', 'example.com'),
             view[0],
             self.next
         )
 
-    def send_login_code(self):
+    def send_login_code(self, secure=False):
         for backend in get_backends():
             if hasattr(backend, 'send_login_code'):
-                backend.send_login_code(self)
+                backend.send_login_code(self, secure=secure)
 
     @classmethod
     def create_code_for_user(cls, user, next=None):

--- a/nopassword/models.py
+++ b/nopassword/models.py
@@ -48,10 +48,10 @@ class LoginCode(models.Model):
             self.next
         )
 
-    def send_login_code(self, secure=False):
+    def send_login_code(self, secure=False, **kwargs):
         for backend in get_backends():
             if hasattr(backend, 'send_login_code'):
-                backend.send_login_code(self, secure=secure)
+                backend.send_login_code(self, secure=secure, **kwargs)
 
     @classmethod
     def create_code_for_user(cls, user, next=None):

--- a/nopassword/views.py
+++ b/nopassword/views.py
@@ -22,7 +22,7 @@ def login(request):
             })[0]
             code.next = request.GET.get('next')
             code.save()
-            code.send_login_code()
+            code.send_login_code(secure=request.is_secure())
             return render(request, 'registration/sent_mail.html')
 
     return django_login(request, authentication_form=AuthenticationForm)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -50,7 +50,10 @@ class AuthenticationBackendTests(unittest.TestCase):
     @skipIf(django.VERSION < (1, 5), 'Custom user not supported')
     @override_settings(AUTH_USER_MODULE='tests.NoUsernameUser')
     def test_email_backend(self):
-        user = get_user_model().objects.create(username='email_user', email='nopassword@example.com')
+        user = get_user_model().objects.create(
+            username='email_user',
+            email='nopassword@example.com',
+        )
         code = LoginCode.create_code_for_user(user, next='/secrets/')
         backend = EmailBackend()
 
@@ -89,4 +92,7 @@ class TestBackendUtils(unittest.TestCase):
         self.assertFalse(self.backend.verify_user(self.inactive_user))
 
     def test_send_login_code(self):
-        self.assertRaises(NotImplementedError, self.backend.send_login_code, code=None, secure=False)
+        self.assertRaises(NotImplementedError,
+                          self.backend.send_login_code,
+                          code=None,
+                          secure=False)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -4,6 +4,7 @@ from unittest import skipIf
 import django
 from django.contrib.auth import authenticate
 from django.test.utils import override_settings, mail
+from django.test import SimpleTestCase
 from django.utils import unittest
 
 from mock import patch, MagicMock
@@ -24,55 +25,74 @@ class AuthenticationBackendTests(unittest.TestCase):
         result = authenticate(username='username')
         self.assertIsNone(result)
 
-    @skipIf(django.VERSION < (1, 5), 'Custom user not supported')
-    @patch('nopassword.backends.sms.TwilioRestClient')
-    @override_settings(AUTH_USER_MODEL='tests.PhoneNumberUser', NOPASSWORD_TWILIO_SID="aaaaaaaa",
-                       NOPASSWORD_TWILIO_AUTH_TOKEN="bbbbbbbb", DEFAULT_FROM_NUMBER="+15555555")
-    def test_twilio_backend(self, mock_object):
+
+@skipIf(django.VERSION < (1, 5), 'Custom user not supported')
+@override_settings(AUTH_USER_MODEL='tests.PhoneNumberUser', NOPASSWORD_TWILIO_SID="aaaaaaaa",
+                   NOPASSWORD_TWILIO_AUTH_TOKEN="bbbbbbbb", DEFAULT_FROM_NUMBER="+15555555")
+class TwilioBackendTests(SimpleTestCase):
+    def setUp(self):
         self.user = get_user_model().objects.create(username='twilio_user')
         self.code = LoginCode.create_code_for_user(self.user, next='/secrets/')
         self.assertEqual(len(self.code.code), 20)
         self.assertIsNotNone(authenticate(username=self.user.username, code=self.code.code))
         self.assertEqual(LoginCode.objects.filter(user=self.user, code=self.code.code).count(), 0)
 
+    def tearDown(self):
+        self.user.delete()
+
+    @patch('nopassword.backends.sms.TwilioRestClient')
+    def test_twilio_backend(self, mock_object):
         self.backend = TwilioBackend()
         self.backend.twilio_client.messages.create = MagicMock()
-
         self.backend.send_login_code(self.code)
         self.assertTrue(mock_object.called)
         self.assertTrue(self.backend.twilio_client.messages.create.called)
+        _, kwargs = self.backend.twilio_client.messages.create.call_args
+        self.assertIn(self.code.login_url(secure=False), kwargs.get('body'))
 
         authenticate(username=self.user.username)
         self.assertEqual(LoginCode.objects.filter(user=self.user).count(), 1)
 
-        self.user.delete()
+    @patch('nopassword.backends.sms.TwilioRestClient')
+    def test_twilio_backend_with_https(self, mock_object):
+        self.backend = TwilioBackend()
+        self.backend.twilio_client.messages.create = MagicMock()
+        self.backend.send_login_code(self.code, secure=True)
+        _, kwargs = self.backend.twilio_client.messages.create.call_args
+        self.assertIn(self.code.login_url(secure=True), kwargs.get('body'))
 
-    @skipIf(django.VERSION < (1, 5), 'Custom user not supported')
-    @override_settings(AUTH_USER_MODULE='tests.NoUsernameUser')
-    def test_email_backend(self):
-        user = get_user_model().objects.create(
+
+@skipIf(django.VERSION < (1, 5), 'Custom user not supported')
+class EmailBackendTests(SimpleTestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create(
             username='email_user',
             email='nopassword@example.com',
         )
-        code = LoginCode.create_code_for_user(user, next='/secrets/')
-        backend = EmailBackend()
+        self.code = LoginCode.create_code_for_user(self.user, next='/secrets/')
+        self.backend = EmailBackend()
 
-        # send mail once with default secure=False
+    def tearDown(self):
+        self.user.delete()
+
+    def test_email_backend(self):
+        "Send email via EmailBackend with default options"
         mail.outbox = []
-        backend.send_login_code(code)
+        self.backend.send_login_code(self.code)
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
-        http_url = code.login_url()
+        http_url = self.code.login_url()
         self.assertIn(http_url, message.body)
         self.assertTrue(http_url.startswith('http:'))
-        self.assertEqual(['nopassword@example.com'], message.to)
+        self.assertEqual([self.user.email], message.to)
 
-        # send again with secure=True
+    def test_email_backend_with_https(self):
+        "Send email via EmailBackend with secure=True"
         mail.outbox = []
-        backend.send_login_code(code, secure=True)
+        self.backend.send_login_code(self.code, secure=True)
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
-        https_url = code.login_url(True)
+        https_url = self.code.login_url(secure=True)
         self.assertTrue(https_url.startswith('https:'))
         self.assertIn(https_url, message.body)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,6 @@
 # -*- coding: utf8 -*-
+from mock import patch
+
 from django.utils import unittest
 from django.http import Http404
 from django.contrib.auth import SESSION_KEY
@@ -77,6 +79,20 @@ class TestViews(unittest.TestCase):
 
         logout = self.c.get('/accounts/logout/')
         self.assertEqual(logout.status_code, 302)
+
+    @patch.object(LoginCode, 'send_login_code')
+    def test_https_request(self, mock_send_login_code):
+        factory = RequestFactory()
+        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, secure=True)
+        self.assertEqual(login.status_code, 200)
+        mock_send_login_code.assert_called_with(secure=True)
+
+    @patch.object(LoginCode, 'send_login_code')
+    def test_http_request(self, mock_send_login_code):
+        factory = RequestFactory()
+        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, secure=False)
+        self.assertEqual(login.status_code, 200)
+        mock_send_login_code.assert_called_with(secure=False)
 
 
 class TestUsersJsonView(unittest.TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -82,15 +82,13 @@ class TestViews(unittest.TestCase):
 
     @patch.object(LoginCode, 'send_login_code')
     def test_https_request(self, mock_send_login_code):
-        factory = RequestFactory()
-        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, secure=True)
+        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, **{'wsgi.url_scheme': 'https'})
         self.assertEqual(login.status_code, 200)
         mock_send_login_code.assert_called_with(secure=True)
 
     @patch.object(LoginCode, 'send_login_code')
     def test_http_request(self, mock_send_login_code):
-        factory = RequestFactory()
-        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, secure=False)
+        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, **{'wsgi.url_scheme': 'http'})
         self.assertEqual(login.status_code, 200)
         mock_send_login_code.assert_called_with(secure=False)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -82,13 +82,17 @@ class TestViews(unittest.TestCase):
 
     @patch.object(LoginCode, 'send_login_code')
     def test_https_request(self, mock_send_login_code):
-        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, **{'wsgi.url_scheme': 'https'})
+        login = self.c.post('/accounts/login/?next=/secret/',
+                            {'username': self.user.username},
+                            **{'wsgi.url_scheme': 'https'})
         self.assertEqual(login.status_code, 200)
         mock_send_login_code.assert_called_with(secure=True)
 
     @patch.object(LoginCode, 'send_login_code')
     def test_http_request(self, mock_send_login_code):
-        login = self.c.post('/accounts/login/?next=/secret/', {'username': self.user.username}, **{'wsgi.url_scheme': 'http'})
+        login = self.c.post('/accounts/login/?next=/secret/',
+                            {'username': self.user.username},
+                            **{'wsgi.url_scheme': 'http'})
         self.assertEqual(login.status_code, 200)
         mock_send_login_code.assert_called_with(secure=False)
 


### PR DESCRIPTION
`LoginCode.login_url` hard-codes 'http':

    return 'http://%s%s?next=%s' % (
        getattr(settings, 'SERVER_URL', 'example.com'),
        view[0],
        self.next
    )

Yes, you should alway set up your webserver to redirect http to https, etc. However, it'd be nice to be able to just use an https url. The problem is, outside the context of a request as we are here, there seems to be no 100% agreed upon way of indicating you're on a HTTPS site. The most common technique seems to be to set an env variable `HTTPS` to `on`, in which case we could do this here:

    return '%s://%s%s?next=%s' % (
        'https' if os.environ.get('HTTPS') === 'on' else 'http',
        getattr(settings, 'SERVER_URL', 'example.com'),
        view[0],
        self.next
    )

Or maybe `LoginCode.send_login_code`, which *does* get called from `nopassword.views.login` and therefore has access to a request object, could accept a `secure` argument (i.e. `code.send_login_code(secure=request.is_secure())`) that could be passed through to the actual `login_url` method of `LoginCode`.

If you've got an opinion on which approach sounds best, I'm happy to work up a pull request!