### PR TITLE
Pass host from request to login_url

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -27,15 +27,19 @@ django-nopassword settings
     By default, the login code url requires a POST request to authenticate the user. A GET request renders ``registration/login_submit.html``, which contains some Javascript that automatically performs the POST on page load. To authenticate directly inside the initial GET request instead, set this to ``False``.
 
 .. attribute:: NOPASSWORD_CODE_LENGTH
+
     The length of the code used to log people in. Default is 20.
 
 .. attribute:: NOPASSWORD_TWILIO_SID
+
     Account ID for Twilio.
 
 .. attribute:: NOPASSWORD_TWILIO_AUTH_TOKEN
+
     Account secret for Twilio
     
 .. attribute:: NOPASSWORD_NUMERIC_CODES
+
     A boolean flag if set to True, codes will contain numeric characters only (0-9). Default: False
 
 Django settings used in django-nopassword
@@ -43,9 +47,13 @@ Django settings used in django-nopassword
 
 .. attribute:: SERVER_URL
 
-Default: `example.com`
+    Default: `example.com`
+
+    By default, ``nopassword.views.login`` passes the result of ``result.get_host()`` to
+    ``LoginCode.send_login_code`` to build the login URL. If you write your own view
+    and/or want to avoid this behavior by not passing a value for host, the
+    ``SERVER_URL`` setting will be used instead.
 
 .. attribute:: DEFAULT_FROM_EMAIL
 
-Default: `root@example.com`
-
+    Default: `root@example.com`

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,12 +48,12 @@ the *EmailBackend*::
 
     class EmailBackend(NoPasswordBackend):
 
-        def send_login_code(self, code, secure=False):
+        def send_login_code(self, code, secure=False, host=None):
             subject = getattr(settings, 'NOPASSWORD_LOGIN_EMAIL_SUBJECT', _('Login code'))
             to_email = [code.user.email]
             from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'root@example.com')
 
-            context = {'url': code.login_url(secure), 'code': code}
+            context = {'url': code.login_url(secure=secure, host=host), 'code': code}
             text_content = render_to_string('registration/login_email.txt', context)
             html_content = render_to_string('registration/login_email.html', context)
 

--- a/nopassword/backends/base.py
+++ b/nopassword/backends/base.py
@@ -32,7 +32,7 @@ class NoPasswordBackend(object):
         except get_user_model().DoesNotExist:
             return None
 
-    def send_login_code(self, code, secure=False, **kwargs):
+    def send_login_code(self, code, secure=False, host=None, **kwargs):
         raise NotImplementedError
 
     def verify_user(self, user):

--- a/nopassword/backends/email.py
+++ b/nopassword/backends/email.py
@@ -9,12 +9,12 @@ from .base import NoPasswordBackend
 
 class EmailBackend(NoPasswordBackend):
 
-    def send_login_code(self, code, secure=False, **kwargs):
+    def send_login_code(self, code, secure=False, host=None, **kwargs):
         subject = getattr(settings, 'NOPASSWORD_LOGIN_EMAIL_SUBJECT', _('Login code'))
         to_email = [code.user.email]
         from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'root@example.com')
 
-        context = {'url': code.login_url(secure=secure), 'code': code}
+        context = {'url': code.login_url(secure=secure, host=host), 'code': code}
         text_content = render_to_string('registration/login_email.txt', context)
         html_content = render_to_string('registration/login_email.html', context)
 

--- a/nopassword/backends/sms.py
+++ b/nopassword/backends/sms.py
@@ -14,13 +14,13 @@ class TwilioBackend(NoPasswordBackend):
         )
         super(TwilioBackend, self).__init__()
 
-    def send_login_code(self, code, secure=False, **kwargs):
+    def send_login_code(self, code, secure=False, host=None, **kwargs):
         """
         Send a login code via SMS
         """
         from_number = getattr(settings, 'DEFAULT_FROM_NUMBER')
 
-        context = {'url': code.login_url(secure=secure), 'code': code}
+        context = {'url': code.login_url(secure=secure, host=host), 'code': code}
         sms_content = render_to_string('registration/login_sms.txt', context)
 
         self.twilio_client.messages.create(

--- a/nopassword/models.py
+++ b/nopassword/models.py
@@ -33,8 +33,9 @@ class LoginCode(models.Model):
             self.next = '/'
         super(LoginCode, self).save(*args, **kwargs)
 
-    def login_url(self, secure=False):
+    def login_url(self, secure=False, host=None):
         username = get_username(self.user)
+        host = host or getattr(settings, 'SERVER_URL', None) or 'example.com'
         if getattr(settings, 'NOPASSWORD_HIDE_USERNAME', False):
             view = reverse_lazy('nopassword.views.login_with_code', args=[self.code]),
         else:
@@ -43,15 +44,15 @@ class LoginCode(models.Model):
 
         return '%s://%s%s?next=%s' % (
             'https' if secure else 'http',
-            getattr(settings, 'SERVER_URL', 'example.com'),
+            host,
             view[0],
             self.next
         )
 
-    def send_login_code(self, secure=False, **kwargs):
+    def send_login_code(self, secure=False, host=None, **kwargs):
         for backend in get_backends():
             if hasattr(backend, 'send_login_code'):
-                backend.send_login_code(self, secure=secure, **kwargs)
+                backend.send_login_code(self, secure=secure, host=host, **kwargs)
 
     @classmethod
     def create_code_for_user(cls, user, next=None):

--- a/nopassword/views.py
+++ b/nopassword/views.py
@@ -19,7 +19,10 @@ def login(request):
             })[0]
             code.next = request.GET.get('next')
             code.save()
-            code.send_login_code(secure=request.is_secure())
+            code.send_login_code(
+                secure=request.is_secure(),
+                host=request.get_host(),
+            )
             return render(request, 'registration/sent_mail.html')
 
     return django_login(request, authentication_form=AuthenticationForm)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -59,7 +59,8 @@ class TwilioBackendTests(SimpleTestCase):
         self.backend.twilio_client.messages.create = MagicMock()
         self.backend.send_login_code(self.code, secure=True, host='secure.example.com')
         _, kwargs = self.backend.twilio_client.messages.create.call_args
-        self.assertIn(self.code.login_url(secure=True, host='secure.example.com'), kwargs.get('body'))
+        login_url = self.code.login_url(secure=True, host='secure.example.com')
+        self.assertIn(login_url, kwargs.get('body'))
 
 
 @skipIf(django.VERSION < (1, 5), 'Custom user not supported')

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -57,9 +57,9 @@ class TwilioBackendTests(SimpleTestCase):
     def test_twilio_backend_with_https(self, mock_object):
         self.backend = TwilioBackend()
         self.backend.twilio_client.messages.create = MagicMock()
-        self.backend.send_login_code(self.code, secure=True)
+        self.backend.send_login_code(self.code, secure=True, host='secure.example.com')
         _, kwargs = self.backend.twilio_client.messages.create.call_args
-        self.assertIn(self.code.login_url(secure=True), kwargs.get('body'))
+        self.assertIn(self.code.login_url(secure=True, host='secure.example.com'), kwargs.get('body'))
 
 
 @skipIf(django.VERSION < (1, 5), 'Custom user not supported')
@@ -89,10 +89,10 @@ class EmailBackendTests(SimpleTestCase):
     def test_email_backend_with_https(self):
         "Send email via EmailBackend with secure=True"
         mail.outbox = []
-        self.backend.send_login_code(self.code, secure=True)
+        self.backend.send_login_code(self.code, secure=True, host='secure.example.com')
         self.assertEqual(1, len(mail.outbox))
         message = mail.outbox[0]
-        https_url = self.code.login_url(secure=True)
+        https_url = self.code.login_url(secure=True, host='secure.example.com')
         self.assertTrue(https_url.startswith('https:'))
         self.assertIn(https_url, message.body)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,13 +13,13 @@ class TestLoginCodes(unittest.TestCase):
     def setUp(self):
         self.user = get_user_model().objects.create(username='test_user')
         self.inactive_user = get_user_model().objects.create(username='inactive', is_active=False)
+        self.code = LoginCode.create_code_for_user(self.user)
 
     def tearDown(self):
         self.user.delete()
         self.inactive_user.delete()
 
     def test_login_backend(self):
-        self.code = LoginCode.create_code_for_user(self.user)
         self.assertEqual(len(self.code.code), 20)
         self.assertIsNotNone(authenticate(username=self.user.username, code=self.code.code))
         self.assertEqual(LoginCode.objects.filter(user=self.user, code=self.code.code).count(), 0)
@@ -32,21 +32,39 @@ class TestLoginCodes(unittest.TestCase):
 
     @override_settings(NOPASSWORD_CODE_LENGTH=8)
     def test_shorter_code(self):
-        self.code = LoginCode.create_code_for_user(self.user)
-        self.assertEqual(len(self.code.code), 8)
+        code = LoginCode.create_code_for_user(self.user)
+        self.assertEqual(len(code.code), 8)
 
     @override_settings(NOPASSWORD_NUMERIC_CODES=True)
     def test_numeric_code(self):
-        self.code = LoginCode.create_code_for_user(self.user)
-        self.assertEqual(len(self.code.code), 20)
-        self.assertTrue(self.code.code.isdigit())
+        code = LoginCode.create_code_for_user(self.user)
+        self.assertEqual(len(code.code), 20)
+        self.assertTrue(code.code.isdigit())
 
     def test_next_value(self):
-        self.code = LoginCode.create_code_for_user(self.user, next='/secrets/')
-        self.assertEqual(self.code.next, '/secrets/')
+        code = LoginCode.create_code_for_user(self.user, next='/secrets/')
+        self.assertEqual(code.next, '/secrets/')
 
     @override_settings(NOPASSWORD_LOGIN_CODE_TIMEOUT=1)
     def test_code_timeout(self):
-        self.timeout_code = LoginCode.create_code_for_user(self.user)
+        timeout_code = LoginCode.create_code_for_user(self.user)
         time.sleep(3)
-        self.assertIsNone(authenticate(username=self.user.username, code=self.timeout_code.code))
+        self.assertIsNone(authenticate(username=self.user.username, code=timeout_code.code))
+
+    def test_login_url_secure(self):
+        self.assertTrue(self.code.login_url(secure=True).startswith('https:'))
+
+    def test_login_url_insecure(self):
+        self.assertTrue(self.code.login_url().startswith('http:'))
+
+    def test_login_url_host(self):
+        host = 'nopassword.example.com'
+        self.assertIn(host, self.code.login_url(host=host))
+
+    @override_settings(SERVER_URL='server_url_setting.example.com')
+    def test_login_url_default_setting(self):
+        self.assertIn('server_url_setting.example.com', self.code.login_url())
+
+    @override_settings(SERVER_URL=None)
+    def test_login_url_no_setting(self):
+        self.assertIn('example.com', self.code.login_url())

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -84,7 +84,7 @@ class TestViews(unittest.TestCase):
                             {'username': self.user.username},
                             **{'wsgi.url_scheme': 'https'})
         self.assertEqual(login.status_code, 200)
-        mock_send_login_code.assert_called_with(secure=True)
+        mock_send_login_code.assert_called_with(secure=True, host='testserver:80')
 
     @patch.object(LoginCode, 'send_login_code')
     def test_http_request(self, mock_send_login_code):
@@ -92,4 +92,4 @@ class TestViews(unittest.TestCase):
                             {'username': self.user.username},
                             **{'wsgi.url_scheme': 'http'})
         self.assertEqual(login.status_code, 200)
-        mock_send_login_code.assert_called_with(secure=False)
+        mock_send_login_code.assert_called_with(secure=False, host='testserver')


### PR DESCRIPTION
See issue #49.

This keeps `SERVER_URL` as a fallback setting in case somebody is using their own login views and/or doesn't want this behavior for some reason.