### PR TITLE
v4.0.1 Fix validation fail for too-long default code length

### DIFF
--- a/nopassword/models.py
+++ b/nopassword/models.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 class LoginCode(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='login_codes',
                              editable=False, verbose_name=_('user'), on_delete=models.CASCADE)
-    code = models.CharField(max_length=20, editable=False, verbose_name=_('code'))
+    code = models.CharField(max_length=64, editable=False, verbose_name=_('code'))
     timestamp = models.DateTimeField(editable=False)
     next = models.TextField(editable=False, blank=True)
 


### PR DESCRIPTION
Hi,

I couldn't create a pull request into `v4.0.1`, but that's my intention here, in order to allow a v4.0.2 patch release. Currently, v4.0.1 does not work (well, it "works" with SQLite, which does not enforce the schema) because the default generated code length is 64, whereas the `max_length` of the `code` column in `LoginCode` is 20. This commit fixes that. Alternatively, the default lower in this file could be changed from 64 to 20.

Fixing this and issuing a 4.0.2 release will help people avoid this failure if they aren't ready to upgrade to 5.0 just just.